### PR TITLE
Compatibility with jsdom 15

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.workingDirectories": [
+    {
+      "pattern": "packages/*"
+    }
+  ]
+}

--- a/packages/universal-wallet-react/package-lock.json
+++ b/packages/universal-wallet-react/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "universal-wallet-react",
+  "name": "@transmute/universal-wallet-react",
   "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/universal-wallet/package-lock.json
+++ b/packages/universal-wallet/package-lock.json
@@ -14,38 +14,25 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-			"integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.12.0",
-				"invariant": "^2.2.4",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==",
+			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
-			"integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
+			"version": "7.12.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+			"integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.4",
-				"@babel/helper-module-transforms": "^7.11.0",
-				"@babel/helpers": "^7.10.4",
-				"@babel/parser": "^7.11.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.11.0",
-				"@babel/types": "^7.11.0",
+				"@babel/generator": "^7.12.5",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helpers": "^7.12.5",
+				"@babel/parser": "^7.12.7",
+				"@babel/template": "^7.12.7",
+				"@babel/traverse": "^7.12.9",
+				"@babel/types": "^7.12.7",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
@@ -57,12 +44,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -86,12 +73,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
-			"integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+			"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0",
+				"@babel/types": "^7.12.5",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			},
@@ -124,15 +111,14 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-			"integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
+			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.10.4",
-				"browserslist": "^4.12.0",
-				"invariant": "^2.2.4",
-				"levenary": "^1.1.1",
+				"@babel/compat-data": "^7.12.5",
+				"@babel/helper-validator-option": "^7.12.1",
+				"browserslist": "^4.14.5",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -145,28 +131,26 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-			"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-member-expression-to-functions": "^7.10.5",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
 				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
 				"@babel/helper-split-export-declaration": "^7.10.4"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-			"integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+			"integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-regex": "^7.10.4",
-				"regexpu-core": "^4.7.0"
+				"regexpu-core": "^4.7.1"
 			}
 		},
 		"@babel/helper-define-map": {
@@ -180,13 +164,46 @@
 				"lodash": "^4.17.19"
 			}
 		},
-		"@babel/helper-explode-assignable-expression": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
-			"integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
+		"@babel/helper-define-polyfill-provider": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.0.3.tgz",
+			"integrity": "sha512-dULDd/APiP4JowYDAMosecKOi/1v+UId99qhBGiO3myM29KtAVKS/R3x3OJJNBR0FeYB1BcYb2dCwkhqvxWXXQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/helper-compilation-targets": "^7.10.4",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2",
+				"semver": "^6.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+			"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -219,45 +236,47 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.5"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
 				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.11.0",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+			"integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -266,56 +285,45 @@
 			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
 			"dev": true
 		},
-		"@babel/helper-regex": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
-			"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.19"
-			}
-		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
-			"integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-wrap-function": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+			"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
 				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
-			"integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -333,10 +341,16 @@
 			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
+			"integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
+			"dev": true
+		},
 		"@babel/helper-wrap-function": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-			"integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+			"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.10.4",
@@ -346,14 +360,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
 			}
 		},
 		"@babel/highlight": {
@@ -420,36 +434,36 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
-			"integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+			"integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
-			"integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-remap-async-to-generator": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1",
 				"@babel/plugin-syntax-async-generators": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-			"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.10.4",
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
-			"integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -457,9 +471,9 @@
 			}
 		},
 		"@babel/plugin-proposal-export-namespace-from": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
-			"integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+			"integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -467,9 +481,9 @@
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
-			"integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -477,9 +491,9 @@
 			}
 		},
 		"@babel/plugin-proposal-logical-assignment-operators": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
-			"integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+			"integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -487,9 +501,9 @@
 			}
 		},
 		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-			"integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+			"integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -497,9 +511,9 @@
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-			"integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -507,20 +521,20 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
-			"integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+			"integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-				"@babel/plugin-transform-parameters": "^7.10.4"
+				"@babel/plugin-transform-parameters": "^7.12.1"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
-			"integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+			"integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -528,33 +542,33 @@
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-			"integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+			"integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-private-methods": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
-			"integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+			"integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.10.4",
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
-			"integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+			"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
@@ -567,10 +581,19 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -592,6 +615,15 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
@@ -658,56 +690,56 @@
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-			"integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-			"integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+			"integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-			"integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-module-imports": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-remap-async-to-generator": "^7.10.4"
+				"@babel/helper-remap-async-to-generator": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-			"integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+			"integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
-			"integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
+			"integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-			"integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+			"integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
@@ -715,52 +747,52 @@
 				"@babel/helper-function-name": "^7.10.4",
 				"@babel/helper-optimise-call-expression": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
 				"@babel/helper-split-export-declaration": "^7.10.4",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-			"integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+			"integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-			"integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+			"integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
-			"integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+			"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
-			"integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
-			"integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+			"integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
@@ -768,18 +800,18 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
-			"integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+			"integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
-			"integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+			"integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.10.4",
@@ -787,255 +819,224 @@
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
-			"integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+			"integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
-			"integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+			"integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
-			"integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
-			"integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+			"integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-simple-access": "^7.12.1",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
-			"integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.10.4",
-				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
-			"integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
-			"integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
-			"integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
-			"integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+			"integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4"
+				"@babel/helper-replace-supers": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-			"integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+			"integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
-			"integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+			"integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
-			"integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+			"integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.2"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
-			"integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
-		"@babel/plugin-transform-runtime": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-			"integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"resolve": "^1.8.1",
-				"semver": "^5.5.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
-			"integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+			"integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
-			"integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+			"integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
-			"integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+			"integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-regex": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
-			"integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+			"integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
-			"integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
+			"integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-unicode-escapes": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
-			"integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+			"integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
-			"integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+			"integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.4.tgz",
-			"integrity": "sha512-8BYcnVqQ5kMD2HXoHInBH7H1b/uP3KdnwCYXOqFnXqguOyuu443WXusbIUbWEfY3Z0Txk0M1uG/8YuAMhNl6zg==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"@babel/preset-env": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-			"integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.7.tgz",
+			"integrity": "sha512-OnNdfAr1FUQg7ksb7bmbKoby4qFOHw6DKWWUNB9KqnnCldxhxJlP+21dpyaWFmf2h0rTbOkXJtAGevY3XW1eew==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.11.0",
-				"@babel/helper-compilation-targets": "^7.10.4",
-				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/compat-data": "^7.12.7",
+				"@babel/helper-compilation-targets": "^7.12.5",
+				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-				"@babel/plugin-proposal-class-properties": "^7.10.4",
-				"@babel/plugin-proposal-dynamic-import": "^7.10.4",
-				"@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-				"@babel/plugin-proposal-json-strings": "^7.10.4",
-				"@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-				"@babel/plugin-proposal-numeric-separator": "^7.10.4",
-				"@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-				"@babel/plugin-proposal-optional-chaining": "^7.11.0",
-				"@babel/plugin-proposal-private-methods": "^7.10.4",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.1",
+				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+				"@babel/plugin-proposal-class-properties": "^7.12.1",
+				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+				"@babel/plugin-proposal-json-strings": "^7.12.1",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.7",
+				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.7",
+				"@babel/plugin-proposal-private-methods": "^7.12.1",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
 				"@babel/plugin-syntax-async-generators": "^7.8.0",
-				"@babel/plugin-syntax-class-properties": "^7.10.4",
+				"@babel/plugin-syntax-class-properties": "^7.12.1",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
 				"@babel/plugin-syntax-json-strings": "^7.8.0",
@@ -1045,45 +1046,42 @@
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-				"@babel/plugin-syntax-top-level-await": "^7.10.4",
-				"@babel/plugin-transform-arrow-functions": "^7.10.4",
-				"@babel/plugin-transform-async-to-generator": "^7.10.4",
-				"@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-				"@babel/plugin-transform-block-scoping": "^7.10.4",
-				"@babel/plugin-transform-classes": "^7.10.4",
-				"@babel/plugin-transform-computed-properties": "^7.10.4",
-				"@babel/plugin-transform-destructuring": "^7.10.4",
-				"@babel/plugin-transform-dotall-regex": "^7.10.4",
-				"@babel/plugin-transform-duplicate-keys": "^7.10.4",
-				"@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-				"@babel/plugin-transform-for-of": "^7.10.4",
-				"@babel/plugin-transform-function-name": "^7.10.4",
-				"@babel/plugin-transform-literals": "^7.10.4",
-				"@babel/plugin-transform-member-expression-literals": "^7.10.4",
-				"@babel/plugin-transform-modules-amd": "^7.10.4",
-				"@babel/plugin-transform-modules-commonjs": "^7.10.4",
-				"@babel/plugin-transform-modules-systemjs": "^7.10.4",
-				"@babel/plugin-transform-modules-umd": "^7.10.4",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-				"@babel/plugin-transform-new-target": "^7.10.4",
-				"@babel/plugin-transform-object-super": "^7.10.4",
-				"@babel/plugin-transform-parameters": "^7.10.4",
-				"@babel/plugin-transform-property-literals": "^7.10.4",
-				"@babel/plugin-transform-regenerator": "^7.10.4",
-				"@babel/plugin-transform-reserved-words": "^7.10.4",
-				"@babel/plugin-transform-shorthand-properties": "^7.10.4",
-				"@babel/plugin-transform-spread": "^7.11.0",
-				"@babel/plugin-transform-sticky-regex": "^7.10.4",
-				"@babel/plugin-transform-template-literals": "^7.10.4",
-				"@babel/plugin-transform-typeof-symbol": "^7.10.4",
-				"@babel/plugin-transform-unicode-escapes": "^7.10.4",
-				"@babel/plugin-transform-unicode-regex": "^7.10.4",
+				"@babel/plugin-syntax-top-level-await": "^7.12.1",
+				"@babel/plugin-transform-arrow-functions": "^7.12.1",
+				"@babel/plugin-transform-async-to-generator": "^7.12.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.1",
+				"@babel/plugin-transform-classes": "^7.12.1",
+				"@babel/plugin-transform-computed-properties": "^7.12.1",
+				"@babel/plugin-transform-destructuring": "^7.12.1",
+				"@babel/plugin-transform-dotall-regex": "^7.12.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.12.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+				"@babel/plugin-transform-for-of": "^7.12.1",
+				"@babel/plugin-transform-function-name": "^7.12.1",
+				"@babel/plugin-transform-literals": "^7.12.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.12.1",
+				"@babel/plugin-transform-modules-amd": "^7.12.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.12.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.12.1",
+				"@babel/plugin-transform-modules-umd": "^7.12.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+				"@babel/plugin-transform-new-target": "^7.12.1",
+				"@babel/plugin-transform-object-super": "^7.12.1",
+				"@babel/plugin-transform-parameters": "^7.12.1",
+				"@babel/plugin-transform-property-literals": "^7.12.1",
+				"@babel/plugin-transform-regenerator": "^7.12.1",
+				"@babel/plugin-transform-reserved-words": "^7.12.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.12.1",
+				"@babel/plugin-transform-spread": "^7.12.1",
+				"@babel/plugin-transform-sticky-regex": "^7.12.7",
+				"@babel/plugin-transform-template-literals": "^7.12.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.1",
+				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
+				"@babel/plugin-transform-unicode-regex": "^7.12.1",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.11.0",
-				"browserslist": "^4.12.0",
-				"core-js-compat": "^3.6.2",
-				"invariant": "^2.2.2",
-				"levenary": "^1.1.1",
+				"@babel/types": "^7.12.7",
+				"core-js-compat": "^3.7.0",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -1096,9 +1094,9 @@
 			}
 		},
 		"@babel/preset-modules": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-			"integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1109,18 +1107,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-			"integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
+			"integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.0.0",
@@ -1128,40 +1126,40 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-			"integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+			"version": "7.12.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+			"integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.0",
+				"@babel/generator": "^7.12.5",
 				"@babel/helper-function-name": "^7.10.4",
 				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.11.0",
-				"@babel/types": "^7.11.0",
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -1173,15 +1171,21 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-			"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+			"integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
 			}
+		},
+		"@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
 		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
@@ -1193,419 +1197,304 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@jest/console": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
-			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.9.0",
-				"chalk": "^2.0.1",
-				"slash": "^2.0.0"
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
 				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
+		"@istanbuljs/schema": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"dev": true
+		},
+		"@jest/console": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
+			"integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"jest-message-util": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"@jest/core": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
+			"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
+				"@jest/console": "^25.5.0",
+				"@jest/reporters": "^25.5.1",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.9.0",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-resolve-dependencies": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"jest-watcher": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"p-each-series": "^1.0.0",
-				"realpath-native": "^1.1.0",
-				"rimraf": "^2.5.4",
-				"slash": "^2.0.0",
-				"strip-ansi": "^5.0.0"
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^25.5.0",
+				"jest-config": "^25.5.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-resolve-dependencies": "^25.5.4",
+				"jest-runner": "^25.5.4",
+				"jest-runtime": "^25.5.4",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"jest-watcher": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^2.1.0",
+				"realpath-native": "^2.0.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
 				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
 		},
 		"@jest/environment": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
-			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+			"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0"
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
-			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+			"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-mock": "^24.9.0"
+				"@jest/types": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"lolex": "^5.0.0"
+			}
+		},
+		"@jest/globals": {
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
+			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"expect": "^25.5.0"
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
+			"integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
-				"istanbul-lib-coverage": "^2.0.2",
-				"istanbul-lib-instrument": "^3.0.1",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.2.6",
-				"jest-haste-map": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.4.2",
-				"slash": "^2.0.0",
+				"graceful-fs": "^4.2.4",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"jest-haste-map": "^25.5.1",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
+				"node-notifier": "^6.0.0",
+				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
-				"string-length": "^2.0.0"
+				"string-length": "^3.1.0",
+				"terminal-link": "^2.0.0",
+				"v8-to-istanbul": "^4.1.3"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"@jest/source-map": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
-			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
+			"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
-				"graceful-fs": "^4.1.15",
+				"graceful-fs": "^4.2.4",
 				"source-map": "^0.6.0"
 			}
 		},
 		"@jest/test-result": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
-			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
+			"integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/istanbul-lib-coverage": "^2.0.0"
+				"@jest/console": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
+			"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0"
+				"@jest/test-result": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-runner": "^25.5.4",
+				"jest-runtime": "^25.5.4"
 			}
 		},
 		"@jest/transform": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
-			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
+			"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.9.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"chalk": "^2.0.1",
+				"@jest/types": "^25.5.0",
+				"babel-plugin-istanbul": "^6.0.0",
+				"chalk": "^3.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.9.0",
-				"jest-regex-util": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"micromatch": "^3.1.10",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-regex-util": "^25.2.6",
+				"jest-util": "^25.5.0",
+				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
+				"realpath-native": "^2.0.0",
+				"slash": "^3.0.0",
 				"source-map": "^0.6.1",
-				"write-file-atomic": "2.4.1"
+				"write-file-atomic": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"@jest/types": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+			"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^13.0.0"
+				"@types/yargs": "^15.0.0",
+				"chalk": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				}
 			}
 		},
 		"@peculiar/asn1-schema": {
@@ -1639,6 +1528,16 @@
 				"webcrypto-core": "^1.1.6"
 			}
 		},
+		"@rollup/plugin-babel": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz",
+			"integrity": "sha512-MjmH7GvFT4TW8xFdIeFS3wqIX646y5tACdxkTO+khbHvS3ZcVJL6vkAHLw2wqPmkhwCfWHoNsp15VYNwW6JEJA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.10.4",
+				"@rollup/pluginutils": "^3.1.0"
+			}
+		},
 		"@rollup/plugin-commonjs": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz",
@@ -1664,26 +1563,27 @@
 			}
 		},
 		"@rollup/plugin-node-resolve": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
-			"integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+			"integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.8",
-				"@types/resolve": "0.0.8",
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
 				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
 				"is-module": "^1.0.0",
-				"resolve": "^1.14.2"
+				"resolve": "^1.17.0"
 			}
 		},
 		"@rollup/plugin-replace": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
-			"integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz",
+			"integrity": "sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.8",
-				"magic-string": "^0.25.5"
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
 			}
 		},
 		"@rollup/pluginutils": {
@@ -1697,6 +1597,15 @@
 				"picomatch": "^2.2.2"
 			}
 		},
+		"@sinonjs/commons": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
 		"@stablelib/aead": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-0.5.0.tgz",
@@ -1706,7 +1615,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
 			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
-			"dev": true,
 			"requires": {
 				"@stablelib/binary": "^1.0.0",
 				"@stablelib/blockcipher": "^1.0.0",
@@ -1717,7 +1625,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
 					"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-					"dev": true,
 					"requires": {
 						"@stablelib/int": "^1.0.0"
 					}
@@ -1725,14 +1632,12 @@
 				"@stablelib/int": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==",
-					"dev": true
+					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
 				},
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				}
 			}
 		},
@@ -1740,7 +1645,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
 			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
-			"dev": true,
 			"requires": {
 				"@stablelib/aes": "^1.0.0",
 				"@stablelib/binary": "^1.0.0",
@@ -1753,7 +1657,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
 					"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-					"dev": true,
 					"requires": {
 						"@stablelib/int": "^1.0.0"
 					}
@@ -1761,20 +1664,17 @@
 				"@stablelib/constant-time": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-					"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA==",
-					"dev": true
+					"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
 				},
 				"@stablelib/int": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==",
-					"dev": true
+					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
 				},
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				}
 			}
 		},
@@ -1789,14 +1689,12 @@
 		"@stablelib/blockcipher": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg==",
-			"dev": true
+			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg=="
 		},
 		"@stablelib/bytes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg==",
-			"dev": true
+			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg=="
 		},
 		"@stablelib/chacha": {
 			"version": "0.7.2",
@@ -1829,7 +1727,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.1.tgz",
 			"integrity": "sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==",
-			"dev": true,
 			"requires": {
 				"@stablelib/random": "^1.0.0",
 				"@stablelib/sha512": "^1.0.0",
@@ -1839,16 +1736,14 @@
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				}
 			}
 		},
 		"@stablelib/hash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.0.tgz",
-			"integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ==",
-			"dev": true
+			"integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ=="
 		},
 		"@stablelib/int": {
 			"version": "0.5.0",
@@ -1859,7 +1754,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
 			"integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
-			"dev": true,
 			"requires": {
 				"@stablelib/bytes": "^1.0.0"
 			}
@@ -1877,7 +1771,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.0.tgz",
 			"integrity": "sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==",
-			"dev": true,
 			"requires": {
 				"@stablelib/binary": "^1.0.0",
 				"@stablelib/wipe": "^1.0.0"
@@ -1887,7 +1780,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
 					"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-					"dev": true,
 					"requires": {
 						"@stablelib/int": "^1.0.0"
 					}
@@ -1895,14 +1787,12 @@
 				"@stablelib/int": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==",
-					"dev": true
+					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
 				},
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				}
 			}
 		},
@@ -1910,7 +1800,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.0.tgz",
 			"integrity": "sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==",
-			"dev": true,
 			"requires": {
 				"@stablelib/binary": "^1.0.0",
 				"@stablelib/hash": "^1.0.0",
@@ -1921,7 +1810,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
 					"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-					"dev": true,
 					"requires": {
 						"@stablelib/int": "^1.0.0"
 					}
@@ -1929,14 +1817,12 @@
 				"@stablelib/int": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==",
-					"dev": true
+					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
 				},
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				}
 			}
 		},
@@ -1949,7 +1835,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
 			"integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
-			"dev": true,
 			"requires": {
 				"@stablelib/keyagreement": "^1.0.0",
 				"@stablelib/random": "^1.0.0",
@@ -1959,8 +1844,7 @@
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				}
 			}
 		},
@@ -1990,7 +1874,6 @@
 			"version": "0.2.1-unstable.23",
 			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.23.tgz",
 			"integrity": "sha512-j7DFn8gK8+sxgMoynmLeCpmJUN2OhxvY0QTzWq9wEQZ4pbm9fq7DOIuizIMpSw0v7DvZja5cgNH+Fkb8E49Ecg==",
-			"dev": true,
 			"requires": {
 				"@stablelib/aes-kw": "^1.0.0",
 				"@stablelib/xchacha20poly1305": "^1.0.0",
@@ -2002,14 +1885,12 @@
 				"@stablelib/aead": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-					"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA==",
-					"dev": true
+					"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
 				},
 				"@stablelib/binary": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
 					"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-					"dev": true,
 					"requires": {
 						"@stablelib/int": "^1.0.0"
 					}
@@ -2018,7 +1899,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
 					"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
-					"dev": true,
 					"requires": {
 						"@stablelib/binary": "^1.0.0",
 						"@stablelib/wipe": "^1.0.0"
@@ -2028,7 +1908,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
 					"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
-					"dev": true,
 					"requires": {
 						"@stablelib/aead": "^1.0.0",
 						"@stablelib/binary": "^1.0.0",
@@ -2041,20 +1920,17 @@
 				"@stablelib/constant-time": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-					"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA==",
-					"dev": true
+					"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
 				},
 				"@stablelib/int": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==",
-					"dev": true
+					"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
 				},
 				"@stablelib/poly1305": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
 					"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
-					"dev": true,
 					"requires": {
 						"@stablelib/constant-time": "^1.0.0",
 						"@stablelib/wipe": "^1.0.0"
@@ -2063,14 +1939,12 @@
 				"@stablelib/wipe": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-					"dev": true
+					"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 				},
 				"@stablelib/xchacha20": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
 					"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-					"dev": true,
 					"requires": {
 						"@stablelib/binary": "^1.0.0",
 						"@stablelib/chacha": "^1.0.0",
@@ -2081,7 +1955,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
 					"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-					"dev": true,
 					"requires": {
 						"@stablelib/aead": "^1.0.0",
 						"@stablelib/chacha20poly1305": "^1.0.0",
@@ -2093,8 +1966,7 @@
 				"web-streams-polyfill": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.0.tgz",
-					"integrity": "sha512-tcZlIJ+VBxuDXdRFF3PCZTJ3yUISGklG4hkl3CDGOlZ8XwpN90L5YsJNoSPH72wZ4nbsatE/OfIaxfM3p+6W7w==",
-					"dev": true
+					"integrity": "sha512-tcZlIJ+VBxuDXdRFF3PCZTJ3yUISGklG4hkl3CDGOlZ8XwpN90L5YsJNoSPH72wZ4nbsatE/OfIaxfM3p+6W7w=="
 				}
 			}
 		},
@@ -2102,7 +1974,6 @@
 			"version": "0.2.1-unstable.23",
 			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.23.tgz",
 			"integrity": "sha512-76P4Lr5k/A8nfJe6cENejJUrFKpBRLMiS8578rQBK5uCJHs1oy9LmCdffk1CjBB935tCnpO2pQLduPl+eOP8YA==",
-			"dev": true,
 			"requires": {
 				"base64url": "^3.0.1",
 				"canonicalize": "^1.0.3"
@@ -2112,7 +1983,6 @@
 			"version": "0.2.1-unstable.23",
 			"resolved": "https://registry.npmjs.org/@transmute/did-key-ed25519/-/did-key-ed25519-0.2.1-unstable.23.tgz",
 			"integrity": "sha512-GYSNo1ZFPKMaV+t8NKKcPCLoFEKcg3zJvPQyXc67kXqghQpUIL2iHj46V2jKGaqqZ5vJPcAG+++4LFZoDqeECQ==",
-			"dev": true,
 			"requires": {
 				"@stablelib/ed25519": "^1.0.1",
 				"@transmute/did-key-common": "^0.2.1-unstable.23",
@@ -2127,7 +1997,6 @@
 			"version": "0.2.1-unstable.23",
 			"resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.23.tgz",
 			"integrity": "sha512-8NP86wM+btvWkopRLO6FKY5bLB2SH0HtRDLdG6XmKEkeTn1Wm6IOssXXLGEHkIF8nfExgt6lEakVcaTKLNPofQ==",
-			"dev": true,
 			"requires": {
 				"@stablelib/ed25519": "^1.0.1",
 				"@stablelib/x25519": "^1.0.0",
@@ -2194,7 +2063,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
 			"integrity": "sha512-OXTmKkrnkwktCX86XA7eWs1TQ6u64enm0syzAfNhjigbuGLy5aLhbhRYWtjt4zzdG/irWudluheRZ9Ic9pCwsA==",
-			"dev": true,
 			"requires": {
 				"asn1.js": "^5.2.0",
 				"base64url": "^3.0.1",
@@ -2210,9 +2078,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-			"integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+			"version": "7.1.12",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+			"integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2223,18 +2091,18 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+			"integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2242,9 +2110,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-			"integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+			"version": "7.0.16",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.16.tgz",
+			"integrity": "sha512-S63Dt4CZOkuTmpLGGWtT/mQdVORJOpx6SZWGVaP56dda/0Nx5nEe82K7/LAm8zYr6SfMq+1N2OreIOrHAx656w==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -2267,6 +2135,15 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
 			"dev": true
+		},
+		"@types/graceful-fs": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+			"integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -2294,18 +2171,19 @@
 			}
 		},
 		"@types/jest": {
-			"version": "24.9.1",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
-			"integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+			"integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
 			"dev": true,
 			"requires": {
-				"jest-diff": "^24.3.0"
+				"jest-diff": "^25.2.1",
+				"pretty-format": "^25.2.1"
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
 			"dev": true
 		},
 		"@types/json5": {
@@ -2315,9 +2193,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-			"integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+			"version": "14.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+			"integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+			"dev": true
+		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -2326,15 +2210,21 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@types/prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+			"dev": true
+		},
 		"@types/pvutils": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/@types/pvutils/-/pvutils-0.0.2.tgz",
 			"integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w=="
 		},
 		"@types/resolve": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -2347,9 +2237,9 @@
 			"dev": true
 		},
 		"@types/yargs": {
-			"version": "13.0.10",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.10.tgz",
-			"integrity": "sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==",
+			"version": "15.0.11",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+			"integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -2413,12 +2303,21 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
 					}
 				},
 				"ms": {
@@ -2428,9 +2327,18 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -2456,15 +2364,15 @@
 			}
 		},
 		"abab": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-			"integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
 		"acorn": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -2478,17 +2386,17 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
 					"dev": true
 				}
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -2532,9 +2440,9 @@
 			}
 		},
 		"ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -2548,13 +2456,13 @@
 			}
 		},
 		"anymatch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
 			}
 		},
 		"argparse": {
@@ -2601,14 +2509,56 @@
 			"dev": true
 		},
 		"array-includes": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-			"integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+			"integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0",
+				"es-abstract": "^1.18.0-next.1",
+				"get-intrinsic": "^1.0.1",
 				"is-string": "^1.0.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"array-unique": {
@@ -2618,24 +2568,106 @@
 			"dev": true
 		},
 		"array.prototype.flat": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+			"integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
+				"es-abstract": "^1.18.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"array.prototype.flatmap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz",
-			"integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+			"integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
+				"es-abstract": "^1.18.0-next.1",
 				"function-bind": "^1.1.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"asmcrypto.js": {
@@ -2655,7 +2687,6 @@
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
 			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -2694,12 +2725,6 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
-		"async-limiter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"dev": true
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2709,6 +2734,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/asyncro/-/asyncro-3.0.0.tgz",
 			"integrity": "sha512-nEnWYfrBmA3taTiuiOoZYmgJ/CNrSoQLeLs29SeLcPu60yaw/mHDBHV0iOZ051fTvsTHxpCY+gXibqT9wbQYfg==",
+			"dev": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
 		},
 		"atob": {
@@ -2728,9 +2759,9 @@
 			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
 		},
 		"axe-core": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-			"integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+			"integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
 			"dev": true
 		},
 		"axios": {
@@ -2764,50 +2795,6 @@
 				"b64-lite": "^1.4.0"
 			}
 		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
 		"babel-eslint": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -2823,85 +2810,31 @@
 			}
 		},
 		"babel-jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
-			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
+			"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/babel__core": "^7.1.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.9.0",
-				"chalk": "^2.4.2",
-				"slash": "^2.0.0"
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"@types/babel__core": "^7.1.7",
+				"babel-plugin-istanbul": "^6.0.0",
+				"babel-preset-jest": "^25.5.0",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-annotate-pure-calls": {
@@ -2926,59 +2859,26 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
-			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+			"integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"find-up": "^3.0.0",
-				"istanbul-lib-instrument": "^3.3.0",
-				"test-exclude": "^5.2.3"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^4.0.0",
+				"test-exclude": "^6.0.0"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
-			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
+			"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
 			"dev": true,
 			"requires": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
@@ -2993,11 +2893,14 @@
 				"resolve": "^1.12.0"
 			}
 		},
-		"babel-plugin-transform-async-to-promises": {
-			"version": "0.8.15",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz",
-			"integrity": "sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==",
-			"dev": true
+		"babel-plugin-polyfill-regenerator": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.0.4.tgz",
+			"integrity": "sha512-+/uCzO9JTYVZVGCpZpVAQkgPGt2zkR0VYiZvJ4aVoCe4ccgpKvNQqcjzAgQzSsjK64Jhc5hvrCR3l0087BevkA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.0.3"
+			}
 		},
 		"babel-plugin-transform-rename-import": {
 			"version": "2.3.0",
@@ -3005,93 +2908,34 @@
 			"integrity": "sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==",
 			"dev": true
 		},
+		"babel-preset-current-node-syntax": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			}
+		},
 		"babel-preset-jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
-			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
+			"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.9.0"
+				"babel-plugin-jest-hoist": "^25.5.0",
+				"babel-preset-current-node-syntax": "^0.1.2"
 			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
-				}
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"globals": {
-					"version": "9.18.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-					"dev": true
-				}
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			},
-			"dependencies": {
-				"to-fast-properties": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-					"dev": true
-				}
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -3202,21 +3046,10 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
 		"bn.js": {
 			"version": "4.11.9",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-			"dev": true
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -3229,69 +3062,18 @@
 			}
 		},
 		"braces": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"split-string": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^3.0.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-							"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-							"dev": true,
-							"requires": {
-								"assign-symbols": "^1.0.0",
-								"is-extendable": "^1.0.1"
-							}
-						},
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				}
+				"fill-range": "^7.0.1"
 			}
 		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
@@ -3317,15 +3099,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
-			"integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
+			"integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001111",
-				"electron-to-chromium": "^1.3.523",
-				"escalade": "^3.0.2",
-				"node-releases": "^1.1.60"
+				"caniuse-lite": "^1.0.30001164",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.612",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.67"
 			}
 		},
 		"bs-logger": {
@@ -3382,32 +3165,32 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
-		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true,
-			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
-			}
-		},
 		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001118",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001118.tgz",
-			"integrity": "sha512-RNKPLojZo74a0cP7jFMidQI7nvLER40HgNfgKQEJ2PFm225L0ectUungNQoK3Xk3StQcFbpBPNEvoWD59436Hg==",
+			"version": "1.0.30001165",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
+			"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
 			"dev": true
 		},
 		"canonicalize": {
@@ -3484,9 +3267,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
-			"integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+			"integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
 			"dev": true
 		},
 		"cli-width": {
@@ -3496,46 +3279,23 @@
 			"dev": true
 		},
 		"cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
 			},
 			"dependencies": {
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -3562,6 +3322,12 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
+		"collect-v8-coverage": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+			"dev": true
+		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3585,6 +3351,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"colorette": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -3625,9 +3397,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"contains-path": {
@@ -3659,19 +3431,13 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-			"dev": true
-		},
 		"core-js-compat": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
-			"integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
+			"integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.5",
+				"browserslist": "^4.15.0",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -3684,9 +3450,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.1.tgz",
+			"integrity": "sha512-Se+LaxqXlVXGvmexKGPvnUIYC1jwXu1H6Pkyb3uBM5d8/NELMYCHs/4/roD7721NxrTLyv7e5nXd5/QLBO+10g==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -3748,18 +3514,26 @@
 			}
 		},
 		"cssom": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+			"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
-			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "~0.3.6"
+			},
+			"dependencies": {
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+					"dev": true
+				}
 			}
 		},
 		"damerau-levenshtein": {
@@ -3785,19 +3559,6 @@
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
 				"whatwg-url": "^7.0.0"
-			},
-			"dependencies": {
-				"whatwg-url": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-					"dev": true,
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
-					}
-				}
 			}
 		},
 		"debug": {
@@ -3825,6 +3586,12 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
 		"defaults": {
@@ -3891,15 +3658,15 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"detect-newline": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
 		"diff-sequences": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
 			"dev": true
 		},
 		"doctrine": {
@@ -3946,16 +3713,15 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.549",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.549.tgz",
-			"integrity": "sha512-q09qZdginlqDH3+Y1P6ch5UDTW8nZ1ijwMkxFs15J/DAWOwqolIx8HZH1UP0vReByBigk/dPlU22xS1MaZ+kpQ==",
+			"version": "1.3.616",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.616.tgz",
+			"integrity": "sha512-CI8L38UN2BEnqXw3/oRIQTmde0LiSeqWSRlPA42ZTYgJQ8fYenzAM2Z3ni+jtILTcrs5aiXZCGJ96Pm+3/yGyQ==",
 			"dev": true
 		},
 		"elliptic": {
 			"version": "6.5.3",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
 			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -4028,9 +3794,9 @@
 			}
 		},
 		"escalade": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-			"integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -4133,12 +3899,12 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"eslint-utils": {
@@ -4177,15 +3943,6 @@
 					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
 					"dev": true
 				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -4198,9 +3955,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-			"integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+			"integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
@@ -4325,9 +4082,9 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-			"integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
@@ -4335,7 +4092,7 @@
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.3",
+				"eslint-import-resolver-node": "^0.3.4",
 				"eslint-module-utils": "^2.6.0",
 				"has": "^1.0.3",
 				"minimatch": "^3.0.4",
@@ -4367,57 +4124,57 @@
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
-			"integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+			"integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.10.2",
+				"@babel/runtime": "^7.11.2",
 				"aria-query": "^4.2.2",
 				"array-includes": "^3.1.1",
 				"ast-types-flow": "^0.0.7",
-				"axe-core": "^3.5.4",
-				"axobject-query": "^2.1.2",
+				"axe-core": "^4.0.2",
+				"axobject-query": "^2.2.0",
 				"damerau-levenshtein": "^1.0.6",
 				"emoji-regex": "^9.0.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1",
+				"jsx-ast-utils": "^3.1.0",
 				"language-tags": "^1.0.5"
 			},
 			"dependencies": {
 				"emoji-regex": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
-					"integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
+					"integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
 					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-			"integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.2.0.tgz",
+			"integrity": "sha512-kOUSJnFjAUFKwVxuzy6sA5yyMx6+o9ino4gCdShzBNx4eyFRudWRYKCFolKjoM40PEiuU6Cn7wBLfq3WsGg7qg==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.20.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
-			"integrity": "sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==",
+			"version": "7.21.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+			"integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
 				"array.prototype.flatmap": "^1.2.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"object.entries": "^1.1.2",
 				"object.fromentries": "^2.0.2",
 				"object.values": "^1.1.1",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.17.0",
+				"resolve": "^1.18.1",
 				"string.prototype.matchall": "^4.0.2"
 			},
 			"dependencies": {
@@ -4439,12 +4196,12 @@
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-			"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
+				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
 			}
 		},
@@ -4503,12 +4260,20 @@
 			}
 		},
 		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
 			}
 		},
 		"estraverse": {
@@ -4536,9 +4301,9 @@
 			"dev": true
 		},
 		"execa": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
-			"integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.0",
@@ -4548,7 +4313,6 @@
 				"merge-stream": "^2.0.0",
 				"npm-run-path": "^4.0.0",
 				"onetime": "^5.1.0",
-				"p-finally": "^2.0.0",
 				"signal-exit": "^3.0.2",
 				"strip-final-newline": "^2.0.0"
 			},
@@ -4647,43 +4411,17 @@
 			}
 		},
 		"expect": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
-			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+			"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.9.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				}
+				"@jest/types": "^25.5.0",
+				"ansi-styles": "^4.0.0",
+				"jest-get-type": "^25.2.6",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-regex-util": "^25.2.6"
 			}
 		},
 		"expo-random": {
@@ -4860,34 +4598,13 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
-		},
 		"fill-range": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				}
+				"to-regex-range": "^5.0.1"
 			}
 		},
 		"find-cache-dir": {
@@ -4899,17 +4616,6 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
 				"pkg-dir": "^4.1.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				}
 			}
 		},
 		"find-up": {
@@ -4988,14 +4694,15 @@
 			}
 		},
 		"fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
 			"dev": true,
 			"requires": {
+				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -5005,15 +4712,11 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.13",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+			"integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"nan": "^2.12.1"
-			}
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -5027,15 +4730,32 @@
 			"dev": true
 		},
 		"gensync": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
 		"get-stdin": {
@@ -5097,9 +4817,9 @@
 			"dev": true
 		},
 		"globalyzer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
-			"integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
 			"dev": true
 		},
 		"globrex": {
@@ -5118,7 +4838,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -5140,23 +4861,6 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"requires": {
 				"function-bind": "^1.1.1"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				}
 			}
 		},
 		"has-flag": {
@@ -5191,6 +4895,26 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -5206,7 +4930,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -5216,7 +4939,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -5283,9 +5005,9 @@
 			"dev": true
 		},
 		"humanize-duration": {
-			"version": "3.23.1",
-			"resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.23.1.tgz",
-			"integrity": "sha512-aoOEkomAETmVuQyBx4E7/LfPlC9s8pAA/USl7vFRQpDjepo3aiyvFfOhtXSDqPowdBVPFUZ7onG/KyuolX0qPg==",
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.24.0.tgz",
+			"integrity": "sha512-B3udnqisaDeRsvUSb+5n2hjxhABI9jotB+i1IEhgHhguTeM5LxIUKoVIu7UpeyaPOygr/Fnv7UhOi45kYYG+tg==",
 			"dev": true
 		},
 		"husky": {
@@ -5332,58 +5054,13 @@
 			}
 		},
 		"import-local": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^3.0.0",
-				"resolve-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -5405,8 +5082,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -5436,12 +5112,6 @@
 				"through": "^2.3.6"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"strip-ansi": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -5474,9 +5144,16 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"optional": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
+		},
+		"ip-regex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -5524,6 +5201,15 @@
 				"ci-info": "^2.0.0"
 			}
 		},
+		"is-core-module": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -5568,6 +5254,13 @@
 				}
 			}
 		},
+		"is-docker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"dev": true,
+			"optional": true
+		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -5601,6 +5294,12 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true
+		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -5608,30 +5307,16 @@
 			"dev": true
 		},
 		"is-negative-zero": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
 			"dev": true
 		},
 		"is-number": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"dev": true,
-			"requires": {
-				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -5690,10 +5375,14 @@
 			"dev": true
 		},
 		"is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -5736,74 +5425,52 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-lib-coverage": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+			"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 			"dev": true,
 			"requires": {
-				"@babel/generator": "^7.4.0",
-				"@babel/parser": "^7.4.3",
-				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.3",
-				"@babel/types": "^7.4.0",
-				"istanbul-lib-coverage": "^2.0.5",
-				"semver": "^6.0.0"
+				"@babel/core": "^7.7.5",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.0.0",
+				"semver": "^6.3.0"
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"supports-color": "^6.1.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^3.0.0",
+				"supports-color": "^7.1.0"
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+			"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"rimraf": "^2.6.3",
+				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -5815,654 +5482,407 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-			"integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
 			"dev": true,
 			"requires": {
-				"html-escaper": "^2.0.0"
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
 			}
 		},
 		"jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
+			"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
 			"dev": true,
 			"requires": {
-				"import-local": "^2.0.0",
-				"jest-cli": "^24.9.0"
+				"@jest/core": "^25.5.4",
+				"import-local": "^3.0.2",
+				"jest-cli": "^25.5.4"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
 				},
 				"jest-cli": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
+					"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"chalk": "^2.0.1",
+						"@jest/core": "^25.5.4",
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
 						"exit": "^0.1.2",
-						"import-local": "^2.0.0",
+						"graceful-fs": "^4.2.4",
+						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-validate": "^24.9.0",
+						"jest-config": "^25.5.4",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
 						"prompts": "^2.0.1",
-						"realpath-native": "^1.1.0",
-						"yargs": "^13.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
+						"realpath-native": "^2.0.0",
+						"yargs": "^15.3.1"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
+			"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"execa": "^1.0.0",
-				"throat": "^4.0.0"
+				"@jest/types": "^25.5.0",
+				"execa": "^3.2.0",
+				"throat": "^5.0.0"
 			},
 			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
 				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-					"dev": true,
-					"requires": {
-						"path-key": "^2.0.0"
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"p-finally": "^2.0.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
 					}
 				},
 				"p-finally": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
 					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
 				}
 			}
 		},
 		"jest-config": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
-			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
+			"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"babel-jest": "^24.9.0",
-				"chalk": "^2.0.1",
+				"@jest/test-sequencer": "^25.5.4",
+				"@jest/types": "^25.5.0",
+				"babel-jest": "^25.5.1",
+				"chalk": "^3.0.0",
+				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.9.0",
-				"jest-environment-node": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"jest-jasmine2": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"pretty-format": "^24.9.0",
-				"realpath-native": "^1.1.0"
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^25.5.0",
+				"jest-environment-node": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"jest-jasmine2": "^25.5.4",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^25.5.0",
+				"realpath-native": "^2.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-diff": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+			"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff-sequences": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"chalk": "^3.0.0",
+				"diff-sequences": "^25.2.6",
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-docblock": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+			"version": "25.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+			"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "^3.0.0"
 			}
 		},
 		"jest-each": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
-			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
+			"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"jest-get-type": "^25.2.6",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
+			"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jsdom": "^11.5.1"
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"jsdom": "^15.2.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
-			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
+			"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-util": "^24.9.0"
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"semver": "^6.3.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
-			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
+			"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"anymatch": "^2.0.0",
+				"@jest/types": "^25.5.0",
+				"@types/graceful-fs": "^4.1.2",
+				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.7",
-				"graceful-fs": "^4.1.15",
-				"invariant": "^2.2.4",
-				"jest-serializer": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.9.0",
-				"micromatch": "^3.1.10",
+				"fsevents": "^2.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-serializer": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
+				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
-				"walker": "^1.0.7"
+				"walker": "^1.0.7",
+				"which": "^2.0.2"
+			},
+			"dependencies": {
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"jest-jasmine2": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
+			"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
+				"@jest/environment": "^25.5.0",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
 				"co": "^4.6.0",
-				"expect": "^24.9.0",
+				"expect": "^25.5.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"pretty-format": "^24.9.0",
-				"throat": "^4.0.0"
+				"jest-each": "^25.5.0",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-runtime": "^25.5.4",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0",
+				"throat": "^5.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-leak-detector": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
-			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
+			"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
-			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+			"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"chalk": "^3.0.0",
+				"jest-diff": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-message-util": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
-			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
+			"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
+				"@jest/types": "^25.5.0",
 				"@types/stack-utils": "^1.0.1",
-				"chalk": "^2.0.1",
-				"micromatch": "^3.1.10",
-				"slash": "^2.0.0",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"micromatch": "^4.0.2",
+				"slash": "^3.0.0",
 				"stack-utils": "^1.0.1"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-mock": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
-			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+			"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0"
+				"@jest/types": "^25.5.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -6472,662 +5892,344 @@
 			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
-			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+			"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
-			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
+			"integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
+				"@jest/types": "^25.5.0",
 				"browser-resolve": "^1.11.3",
-				"chalk": "^2.0.1",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.1",
-				"realpath-native": "^1.1.0"
+				"read-pkg-up": "^7.0.1",
+				"realpath-native": "^2.0.0",
+				"resolve": "^1.17.0",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
 					}
 				}
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
+			"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.9.0"
+				"@jest/types": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-snapshot": "^25.5.1"
 			}
 		},
 		"jest-runner": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
-			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
+			"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.4.2",
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.9.0",
-				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-jasmine2": "^24.9.0",
-				"jest-leak-detector": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.4",
+				"jest-docblock": "^25.3.0",
+				"jest-haste-map": "^25.5.1",
+				"jest-jasmine2": "^25.5.4",
+				"jest-leak-detector": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"jest-runtime": "^25.5.4",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
 				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
+				"throat": "^5.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-runtime": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
-			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
+			"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.9.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"chalk": "^2.0.1",
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/globals": "^25.5.2",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^3.0.0",
+				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
-				"strip-bom": "^3.0.0",
-				"yargs": "^13.3.0"
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"realpath-native": "^2.0.0",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0",
+				"yargs": "^15.3.1"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
-			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
-			"dev": true
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
+			"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.4"
+			}
 		},
 		"jest-snapshot": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
-			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
+			"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"expect": "^24.9.0",
-				"jest-diff": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"mkdirp": "^0.5.1",
+				"@jest/types": "^25.5.0",
+				"@types/prettier": "^1.19.0",
+				"chalk": "^3.0.0",
+				"expect": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"make-dir": "^3.0.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.9.0",
-				"semver": "^6.2.0"
+				"pretty-format": "^25.5.0",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-util": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
-			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+			"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/source-map": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"callsites": "^3.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.15",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
 				"is-ci": "^2.0.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0"
+				"make-dir": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-validate": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+			"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
+				"@jest/types": "^25.5.0",
 				"camelcase": "^5.3.1",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
+				"chalk": "^3.0.0",
+				"jest-get-type": "^25.2.6",
 				"leven": "^3.1.0",
-				"pretty-format": "^24.9.0"
+				"pretty-format": "^25.5.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
 				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-watch-typeahead": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.4.2.tgz",
-			"integrity": "sha512-f7VpLebTdaXs81rg/oj4Vg/ObZy2QtGzAmGLNsqUS5G5KtSN68tFcIsbvNODfNyQxU78g7D8x77o3bgfBTR+2Q==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.5.0.tgz",
+			"integrity": "sha512-4r36w9vU8+rdg48hj0Z7TvcSqVP6Ao8dk04grlHQNgduyCB0SqrI0xWIl85ZhXrzYvxQ0N5H+rRLAejkQzEHeQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^2.4.1",
-				"jest-regex-util": "^24.9.0",
-				"jest-watcher": "^24.3.0",
+				"chalk": "^3.0.0",
+				"jest-regex-util": "^25.2.1",
+				"jest-watcher": "^25.2.4",
 				"slash": "^3.0.0",
 				"string-length": "^3.1.0",
-				"strip-ansi": "^5.0.0"
+				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"string-length": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-					"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"astral-regex": "^1.0.0",
-						"strip-ansi": "^5.2.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
 		},
 		"jest-watcher": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
-			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
+			"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"jest-util": "^24.9.0",
-				"string-length": "^2.0.0"
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
+				"jest-util": "^25.5.0",
+				"string-length": "^3.1.0"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				}
 			}
 		},
 		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+			"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
 			"dev": true,
 			"requires": {
 				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"supports-color": "^7.0.0"
 			}
 		},
 		"jpjs": {
@@ -7157,44 +6259,49 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdom": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"version": "15.2.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+			"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
+				"acorn": "^7.1.0",
+				"acorn-globals": "^4.3.2",
 				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
+				"cssom": "^0.4.1",
+				"cssstyle": "^2.0.0",
+				"data-urls": "^1.1.0",
 				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
+				"escodegen": "^1.11.1",
 				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
-				"parse5": "4.0.0",
+				"nwsapi": "^2.2.0",
+				"parse5": "5.1.0",
 				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
+				"request": "^2.88.0",
+				"request-promise-native": "^1.0.7",
+				"saxes": "^3.1.9",
 				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
+				"tough-cookie": "^3.0.1",
 				"w3c-hr-time": "^1.0.1",
+				"w3c-xmlserializer": "^1.1.2",
 				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^7.0.0",
+				"ws": "^7.0.0",
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "5.7.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-					"dev": true
+				"tough-cookie": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+					"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+					"dev": true,
+					"requires": {
+						"ip-regex": "^2.1.0",
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
 				}
 			}
 		},
@@ -7202,12 +6309,6 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
-		},
-		"json-parse-better-errors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
 		"json-parse-even-better-errors": {
@@ -7247,12 +6348,21 @@
 			}
 		},
 		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
 			}
 		},
 		"jsonld": {
@@ -7330,13 +6440,27 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-			"integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
+			"integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
-				"object.assign": "^4.1.0"
+				"object.assign": "^4.1.1"
+			},
+			"dependencies": {
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"kind-of": {
@@ -7351,9 +6475,9 @@
 			"dev": true
 		},
 		"language-subtag-registry": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
-			"integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+			"version": "0.3.21",
+			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
+			"integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
 			"dev": true
 		},
 		"language-tags": {
@@ -7365,26 +6489,11 @@
 				"language-subtag-registry": "~0.3.2"
 			}
 		},
-		"left-pad": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-			"dev": true
-		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
-		},
-		"levenary": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
-			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-			"dev": true,
-			"requires": {
-				"leven": "^3.1.0"
-			}
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -7439,6 +6548,12 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7458,12 +6573,12 @@
 			"dev": true
 		},
 		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "^2.4.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7612,6 +6727,15 @@
 				}
 			}
 		},
+		"lolex": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7621,10 +6745,21 @@
 			}
 		},
 		"lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+					"dev": true
+				}
+			}
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -7644,27 +6779,12 @@
 			}
 		},
 		"make-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 			"dev": true,
 			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
+				"semver": "^6.0.0"
 			}
 		},
 		"make-error": {
@@ -7704,24 +6824,13 @@
 			"dev": true
 		},
 		"micromatch": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"braces": "^3.0.1",
+				"picomatch": "^2.0.5"
 			}
 		},
 		"mime-db": {
@@ -7768,14 +6877,12 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -7854,8 +6961,7 @@
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -7889,12 +6995,21 @@
 			"dev": true
 		},
 		"no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
 			"dev": true,
 			"requires": {
-				"lower-case": "^1.1.1"
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+					"dev": true
+				}
 			}
 		},
 		"node-fetch": {
@@ -7928,37 +7043,29 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+			"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"is-wsl": "^1.1.0",
-				"semver": "^5.5.0",
+				"is-wsl": "^2.1.1",
+				"semver": "^6.3.0",
 				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
+				"which": "^1.3.1"
 			}
 		},
 		"node-releases": {
-			"version": "1.1.60",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-			"integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+			"version": "1.1.67",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
 			"dev": true
 		},
 		"node-webcrypto-ossl": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-2.1.2.tgz",
 			"integrity": "sha512-EkrrRUWW+2QrsZ8PZfPSaRlWg38WOv2/mZTcW0l2SbEYERJ0G3OkW6kBiTpzUtcM+2PBaspNRZPfpBvvLp0NTQ==",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^1.0.4",
 				"nan": "^2.14.1",
@@ -7970,8 +7077,7 @@
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				}
 			}
 		},
@@ -7996,13 +7102,10 @@
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
@@ -8099,14 +7202,55 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-			"integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+			"integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
+				"es-abstract": "^1.18.0-next.1",
 				"has": "^1.0.3"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"object.fromentries": {
@@ -8120,16 +7264,6 @@
 				"has": "^1.0.3"
 			}
 		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
-			}
-		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -8140,15 +7274,55 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+			"integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
+				"es-abstract": "^1.18.0-next.1",
 				"has": "^1.0.3"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"once": {
@@ -8190,110 +7364,38 @@
 			}
 		},
 		"ora": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
-			"integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
-				"cli-spinners": "^2.0.0",
-				"log-symbols": "^2.2.0",
-				"strip-ansi": "^5.2.0",
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.2.0",
+				"is-interactive": "^1.0.0",
+				"log-symbols": "^3.0.0",
+				"mute-stream": "0.0.8",
+				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"cli-cursor": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"dev": true
-				},
-				"onetime": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-					"dev": true,
-					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -8305,18 +7407,15 @@
 			"dev": true
 		},
 		"p-each-series": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-			"dev": true,
-			"requires": {
-				"p-reduce": "^1.0.0"
-			}
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+			"integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+			"dev": true
 		},
 		"p-finally": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-			"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
 		"p-limit": {
@@ -8336,12 +7435,6 @@
 			"requires": {
 				"p-limit": "^2.2.0"
 			}
-		},
-		"p-reduce": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-			"dev": true
 		},
 		"p-try": {
 			"version": "2.2.0",
@@ -8377,19 +7470,27 @@
 			}
 		},
 		"parse5": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
 			"dev": true
 		},
 		"pascal-case": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
 			"dev": true,
 			"requires": {
-				"camel-case": "^3.0.0",
-				"upper-case-first": "^1.1.0"
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+					"dev": true
+				}
 			}
 		},
 		"pascalcase": {
@@ -8506,41 +7607,15 @@
 			}
 		},
 		"pretty-format": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+			"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-regex": "^4.0.0",
-				"ansi-styles": "^3.2.0",
-				"react-is": "^16.8.4"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				}
+				"@jest/types": "^25.5.0",
+				"ansi-regex": "^5.0.0",
+				"ansi-styles": "^4.0.0",
+				"react-is": "^16.12.0"
 			}
 		},
 		"progress": {
@@ -8620,13 +7695,13 @@
 			}
 		},
 		"prompts": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.4"
+				"sisteransi": "^1.0.5"
 			}
 		},
 		"prop-types": {
@@ -8673,6 +7748,15 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"rdf-canonize": {
 			"version": "1.1.0",
@@ -8781,13 +7865,10 @@
 			}
 		},
 		"realpath-native": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
-			"dev": true,
-			"requires": {
-				"util.promisify": "^1.0.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+			"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+			"dev": true
 		},
 		"rechoir": {
 			"version": "0.6.2",
@@ -8799,9 +7880,9 @@
 			}
 		},
 		"regenerate": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
-			"integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
@@ -8855,9 +7936,9 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-			"integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -8976,27 +8057,28 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
 			"dev": true,
 			"requires": {
+				"is-core-module": "^2.1.0",
 				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "^5.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				}
 			}
@@ -9049,65 +8131,114 @@
 				"acorn": "^7.1.0"
 			}
 		},
-		"rollup-plugin-babel": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-			"integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"rollup-pluginutils": "^2.8.1"
-			}
-		},
 		"rollup-plugin-sourcemaps": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz",
-			"integrity": "sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz",
+			"integrity": "sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==",
 			"dev": true,
 			"requires": {
-				"rollup-pluginutils": "^2.0.1",
-				"source-map-resolve": "^0.5.0"
+				"@rollup/pluginutils": "^3.0.9",
+				"source-map-resolve": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map-resolve": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+					"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+					"dev": true,
+					"requires": {
+						"atob": "^2.1.2",
+						"decode-uri-component": "^0.2.0"
+					}
+				}
 			}
 		},
 		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz",
+			"integrity": "sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"jest-worker": "^24.9.0",
 				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
+				"serialize-javascript": "^4.0.0",
 				"terser": "^4.6.2"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"jest-worker": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+					"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+					"dev": true,
+					"requires": {
+						"merge-stream": "^2.0.0",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"rollup-plugin-typescript2": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.26.0.tgz",
-			"integrity": "sha512-lUK7XZVG77tu8dmv1L/0LZFlavED/5Yo6e4iMMl6fdox/yKdj4IFRRPPJEXNdmEaT1nDQQeCi7b5IwKHffMNeg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.3.tgz",
+			"integrity": "sha512-gmYPIFmALj9D3Ga1ZbTZAKTXq1JKlTQBtj299DXhqYz9cL3g/AQfUvbb2UhH+Nf++cCq941W2Mv7UcrcgLzJJg==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^3.2.0",
+				"@rollup/pluginutils": "^3.1.0",
+				"find-cache-dir": "^3.3.1",
 				"fs-extra": "8.1.0",
-				"resolve": "1.15.1",
-				"rollup-pluginutils": "2.8.2",
-				"tslib": "1.10.0"
+				"resolve": "1.17.0",
+				"tslib": "2.0.1"
 			},
 			"dependencies": {
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
 				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
 				},
-				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+				"universalify": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 					"dev": true
 				}
 			}
@@ -9142,26 +8273,26 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-			"integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+			"integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-					"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true
 				}
 			}
 		},
 		"sade": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.3.tgz",
-			"integrity": "sha512-m4BctppMvJ60W1dXnHq7jMmFe3hPJZDAH85kQ3ACTo7XZNVUuTItCQ+2HfyaMeV5cKrbw7l4vD/6We3GBxvdJw==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
 			"dev": true,
 			"requires": {
 				"mri": "^1.1.0"
@@ -9203,6 +8334,45 @@
 				"walker": "~1.0.5"
 			},
 			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
 				"execa": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -9218,6 +8388,29 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -9227,11 +8420,61 @@
 						"pump": "^3.0.0"
 					}
 				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
 				"is-stream": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
@@ -9242,19 +8485,35 @@
 						"path-key": "^2.0.0"
 					}
 				},
-				"p-finally": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-					"dev": true
+				"split-string": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
 				}
 			}
 		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+		"saxes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.1.1"
+			}
 		},
 		"security-context": {
 			"version": "4.0.0",
@@ -9297,10 +8556,13 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -9399,7 +8661,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"side-channel": {
 			"version": "1.0.3",
@@ -9412,23 +8675,41 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0-next.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.0",
+						"is-callable": "^1.2.2",
 						"is-negative-zero": "^2.0.0",
 						"is-regex": "^1.1.1",
 						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
+						"object.assign": "^4.1.1",
 						"string.prototype.trimend": "^1.0.1",
 						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
 					}
 				}
 			}
@@ -9693,9 +8974,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
 			"dev": true
 		},
 		"split-string": {
@@ -9727,10 +9008,21 @@
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
-			"dev": true
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.4.tgz",
+			"integrity": "sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -9765,30 +9057,13 @@
 			"integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
 		},
 		"string-length": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+			"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
 			"dev": true,
 			"requires": {
 				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"strip-ansi": "^5.2.0"
 			}
 		},
 		"string-width": {
@@ -9802,12 +9077,6 @@
 				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"strip-ansi": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -9820,17 +9089,58 @@
 			}
 		},
 		"string.prototype.matchall": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
-			"integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+			"integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0",
+				"es-abstract": "^1.18.0-next.1",
 				"has-symbols": "^1.0.1",
 				"internal-slot": "^1.0.2",
 				"regexp.prototype.flags": "^1.3.0",
-				"side-channel": "^1.0.2"
+				"side-channel": "^1.0.3"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"string.prototype.trimend": {
@@ -9852,18 +9162,18 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "^4.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				}
 			}
@@ -9899,6 +9209,16 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-hyperlinks": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			}
 		},
 		"symbol-tree": {
@@ -9941,16 +9261,17 @@
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^5.1.0"
 					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
 				}
+			}
+		},
+		"terminal-link": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"supports-hyperlinks": "^2.0.0"
 			}
 		},
 		"terser": {
@@ -9965,109 +9286,14 @@
 			}
 		},
 		"test-exclude": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.3",
-				"minimatch": "^3.0.4",
-				"read-pkg-up": "^4.0.0",
-				"require-main-filename": "^2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				}
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
 			}
 		},
 		"text-table": {
@@ -10077,9 +9303,9 @@
 			"dev": true
 		},
 		"throat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"dev": true
 		},
 		"through": {
@@ -10089,13 +9315,13 @@
 			"dev": true
 		},
 		"tiny-glob": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
-			"integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
+			"integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
 			"dev": true,
 			"requires": {
-				"globalyzer": "^0.1.0",
-				"globrex": "^0.1.1"
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
 			}
 		},
 		"tmp": {
@@ -10152,13 +9378,12 @@
 			}
 		},
 		"to-regex-range": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "^7.0.0"
 			}
 		},
 		"tough-cookie": {
@@ -10180,9 +9405,9 @@
 			}
 		},
 		"ts-jest": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
-			"integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.5.1.tgz",
+			"integrity": "sha512-kHEUlZMK8fn8vkxDjwbHlxXRB9dHYpyzqKIGDNxbzs+Rz+ssNDSDNusEK8Fk/sDd4xE6iKoQLfFkFVaskmTJyw==",
 			"dev": true,
 			"requires": {
 				"bs-logger": "0.x",
@@ -10191,33 +9416,10 @@
 				"json5": "2.x",
 				"lodash.memoize": "4.x",
 				"make-error": "1.x",
+				"micromatch": "4.x",
 				"mkdirp": "0.x",
-				"resolve": "1.x",
-				"semver": "^5.5",
-				"yargs-parser": "10.x"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
+				"semver": "6.x",
+				"yargs-parser": "18.x"
 			}
 		},
 		"tsconfig-paths": {
@@ -10244,26 +9446,23 @@
 			}
 		},
 		"tsdx": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/tsdx/-/tsdx-0.13.3.tgz",
-			"integrity": "sha512-IzEzSygWpGC/E6UQ1rPxRRpeRLPQ3RBSmisTcX2p9PKFItrwG50MaW8DfVDIolkk4Xt9cYUfgjJ+g01qN2gMYQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/tsdx/-/tsdx-0.14.1.tgz",
+			"integrity": "sha512-keHmFdCL2kx5nYFlBdbE3639HQ2v9iGedAFAajobrUTH2wfX0nLPdDhbHv+GHLQZqf0c5ur1XteE8ek/+Eyj5w==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.4.4",
 				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/parser": "^7.11.5",
 				"@babel/plugin-proposal-class-properties": "^7.4.4",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
-				"@babel/plugin-proposal-optional-chaining": "^7.7.5",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.4.5",
-				"@babel/plugin-transform-runtime": "^7.6.0",
-				"@babel/polyfill": "^7.4.4",
-				"@babel/preset-env": "^7.4.4",
+				"@babel/preset-env": "^7.11.0",
+				"@babel/traverse": "^7.11.5",
+				"@rollup/plugin-babel": "^5.1.0",
 				"@rollup/plugin-commonjs": "^11.0.0",
 				"@rollup/plugin-json": "^4.0.0",
-				"@rollup/plugin-node-resolve": "^7.1.0",
+				"@rollup/plugin-node-resolve": "^9.0.0",
 				"@rollup/plugin-replace": "^2.2.1",
-				"@types/jest": "^24.0.15",
+				"@types/jest": "^25.2.1",
 				"@typescript-eslint/eslint-plugin": "^2.12.0",
 				"@typescript-eslint/parser": "^2.12.0",
 				"ansi-escapes": "^4.2.1",
@@ -10272,112 +9471,72 @@
 				"babel-plugin-annotate-pure-calls": "^0.4.0",
 				"babel-plugin-dev-expression": "^0.2.1",
 				"babel-plugin-macros": "^2.6.1",
-				"babel-plugin-transform-async-to-promises": "^0.8.14",
+				"babel-plugin-polyfill-regenerator": "^0.0.4",
 				"babel-plugin-transform-rename-import": "^2.3.0",
-				"babel-traverse": "^6.26.0",
-				"babylon": "^6.18.0",
-				"camelcase": "^5.2.0",
-				"chalk": "^2.4.2",
+				"camelcase": "^6.0.0",
+				"chalk": "^4.0.0",
 				"enquirer": "^2.3.4",
 				"eslint": "^6.1.0",
 				"eslint-config-prettier": "^6.0.0",
-				"eslint-config-react-app": "^5.0.2",
+				"eslint-config-react-app": "^5.2.1",
 				"eslint-plugin-flowtype": "^3.13.0",
 				"eslint-plugin-import": "^2.18.2",
 				"eslint-plugin-jsx-a11y": "^6.2.3",
 				"eslint-plugin-prettier": "^3.1.0",
 				"eslint-plugin-react": "^7.14.3",
 				"eslint-plugin-react-hooks": "^2.2.0",
-				"execa": "3.2.0",
-				"fs-extra": "^8.0.1",
-				"jest": "^24.8.0",
-				"jest-watch-typeahead": "^0.4.0",
+				"execa": "^4.0.3",
+				"fs-extra": "^9.0.0",
+				"jest": "^25.3.0",
+				"jest-watch-typeahead": "^0.5.0",
 				"jpjs": "^1.2.1",
 				"lodash.merge": "^4.6.2",
-				"ora": "^3.4.0",
-				"pascal-case": "^2.0.1",
+				"ora": "^4.0.3",
+				"pascal-case": "^3.1.1",
 				"prettier": "^1.19.1",
 				"progress-estimator": "^0.2.2",
+				"regenerator-runtime": "^0.13.7",
 				"rollup": "^1.32.1",
-				"rollup-plugin-babel": "^4.3.2",
-				"rollup-plugin-sourcemaps": "^0.4.2",
+				"rollup-plugin-sourcemaps": "^0.6.2",
 				"rollup-plugin-terser": "^5.1.2",
-				"rollup-plugin-typescript2": "^0.26.0",
+				"rollup-plugin-typescript2": "^0.27.3",
 				"sade": "^1.4.2",
 				"semver": "^7.1.1",
 				"shelljs": "^0.8.3",
 				"tiny-glob": "^0.2.6",
-				"ts-jest": "^24.0.2",
+				"ts-jest": "^25.3.1",
 				"tslib": "^1.9.3",
 				"typescript": "^3.7.3"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"yallist": "^4.0.0"
 					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
 				},
 				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"lru-cache": "^6.0.0"
 					}
 				},
 				"tslib": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-					"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true
 				},
-				"typescript": {
-					"version": "3.9.7",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-					"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -10397,9 +9556,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-					"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true
 				}
 			}
@@ -10426,11 +9585,26 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
+		},
 		"type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"typescript": {
 			"version": "3.9.7",
@@ -10479,9 +9653,9 @@
 			}
 		},
 		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
 			"dev": true
 		},
 		"unset-value": {
@@ -10524,21 +9698,6 @@
 				}
 			}
 		},
-		"upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-			"dev": true
-		},
-		"upper-case-first": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-			"integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-			"dev": true,
-			"requires": {
-				"upper-case": "^1.1.1"
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -10559,28 +9718,35 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
-			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			}
-		},
 		"uuid": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
 			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
 		},
 		"v8-compile-cache": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
 			"dev": true
+		},
+		"v8-to-istanbul": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+			"integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^1.6.0",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
+			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -10609,6 +9775,17 @@
 			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^1.0.0"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"dev": true,
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"walker": {
@@ -10673,9 +9850,9 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
@@ -10711,70 +9888,23 @@
 			"dev": true
 		},
 		"wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -10795,29 +9925,33 @@
 			}
 		},
 		"write-file-atomic": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
-			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"ws": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-			"dev": true,
-			"requires": {
-				"async-limiter": "~1.0.0"
-			}
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+			"integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
 		"xmldom": {
@@ -10826,9 +9960,9 @@
 			"integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
 			"dev": true
 		},
 		"yallist": {
@@ -10843,99 +9977,40 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 			"dev": true,
 			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
 				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
+				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.2"
-			},
-			"dependencies": {
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
+				"yargs-parser": "^18.1.2"
 			}
 		},
 		"yargs-parser": {
-			"version": "13.1.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				}
 			}
 		}
 	}

--- a/packages/universal-wallet/package.json
+++ b/packages/universal-wallet/package.json
@@ -38,7 +38,7 @@
     "@transmute/vc.js": "^0.1.1-unstable.1",
     "edv-client": "^4.0.1",
     "husky": "^4.2.5",
-    "tsdx": "^0.13.2",
+    "tsdx": "^0.14.1",
     "tslib": "^2.0.0",
     "typescript": "^3.8.3"
   },


### PR DESCRIPTION
Tests are not passing because of a heap error. 

tsdx@14.1 upgraded to jest@25 which uses jsdom v15 instead of jsdom v11.

For some reasons jsdom@15 breaks minimal-cipher which is a dependency of the universal-wallet.

Minimal reproduction of the error: https://github.com/gjgd/minimal-cipher-jest-bug

Issue in jest repo: https://github.com/facebook/jest/issues/9457#issuecomment-739522254 